### PR TITLE
update readme to point to Axentro in deps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add this to your application's `shard.yml`:
 ```yaml
 dependencies:
   crypto-mnemonic:
-    github: SushiChain/crypto-mnemonic
+    github: Axentro/crypto-mnemonic
 ```
 
 ## Usage


### PR DESCRIPTION
This will update the README.md doc to reference Axentro/crypto-mnemonic in the deps section rather than SushiChain/crypto-mnemonic